### PR TITLE
Update pop up styling and add data labels (on hover)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6,8 +6,8 @@
   --secondary-color: gray;
   --warning-color: red;
   --bg-color: #fff;
-  --marker-border: #0f52ba;
-  --marker-fill: #c0d3e0;
+  --marker-border: #002d71;
+  --marker-fill: #c0d3ff;
 }
 
 *,
@@ -87,16 +87,16 @@ button {
 }
 
 .map__popupItem {
-  font-size: small;
+  font-size: smaller;
 }
 
 .map__popupValue {
-  font-size: medium;
+  font-size: small;
   font-weight: bold;
 }
 
 .map__popupRow {
-  padding-bottom: 0.4em;
+  padding-bottom: 0.2em;
 }
 
 .legend {
@@ -141,4 +141,53 @@ button {
 #warning-display {
   font-size: small;
   color: var(--warning-color);
+}
+
+.leaflet-tooltip-top:before, 
+.leaflet-tooltip-bottom:before, 
+.leaflet-tooltip-left:before, 
+.leaflet-tooltip-right:before {
+    border: none;
+}
+
+.leaflet-tooltip {
+  background: rgba(256, 256, 256, 0.9);
+  border: none;
+  font-size: 12px;
+  box-shadow: none;
+}
+
+.leaflet-popup-tip-container {
+  width: 90px;
+  position: absolute;
+  top: 10px;
+}
+
+.leaflet-popup-tip {
+  max-width: 15px;
+  max-height: 15px;
+  background: rgba(0, 0, 0, 0);
+  border: solid var(--marker-border) 2px;
+  box-shadow: none;
+}
+
+.leaflet-popup-content-wrapper {
+  background: rgba(256, 256, 256, 0);
+  border: none;
+  box-shadow: none;
+  position: absolute;
+  top: 10px;
+  color: var(--marker-border);
+}
+
+.leaflet-popup-close-button {
+  background: var(--marker-fill) !important;
+  position: absolute;
+  left: 100px;
+  font-weight: bold;
+  border-radius: 50%;
+}
+
+.fa-angle-down {
+  font-size: 18px;
 }

--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   
   <link rel="icon" type="image/png" sizes="32x32" href="#">
   <link rel="icon" type="image/png" sizes="32x32" href="#">
-  <link rel="stylesheet" type="text/css" href="css/styles.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+  <link rel="stylesheet" type="text/css" href="css/styles.css">
   <title>Fireball</title>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="assets/data.js"></script>

--- a/js/map.js
+++ b/js/map.js
@@ -142,7 +142,13 @@ function generateMap() {
                             <div class="map__popupValue">${feature.properties.year}</div>
                         </div>
                     </div>
-                `, {});
+                `, {
+                    
+                });
+
+                layer.bindTooltip(`${feature.properties.name}`, {
+                    direction: 'top'
+                });
             }
         },
         pointToLayer: function (feature, latlng) {
@@ -150,8 +156,8 @@ function generateMap() {
                 return L.circleMarker(latlng, {
                     renderer: myRenderer,
                     radius: calculateRadius(feature.properties["mass (g)"]),
-                    fillColor:"#598baf",
-                    color: "#0f52ba",
+                    fillColor:"#294baf",
+                    color: "#0f52ba"
                 });
             }
         }


### PR DESCRIPTION
Adjust map styling of popup to be closer to wireframe. Also add labels to show the name (on hover). Could not find a way to include static labels next to all data points that maintained performance #16 